### PR TITLE
env variables created and used in settings for better security

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,7 +102,7 @@ celerybeat.pid
 *.sage.py
 
 # Environments
-.env
+ecommerce/ecommerce/.env
 .venv
 env/
 venv/
@@ -129,3 +129,6 @@ dmypy.json
 .pyre/
 .idea
 static/
+
+#environs
+/ecommerce/ecommerce/.env

--- a/ecommerce/ecommerce/settings.py
+++ b/ecommerce/ecommerce/settings.py
@@ -11,21 +11,28 @@ https://docs.djangoproject.com/en/3.2/ref/settings/
 """
 
 from pathlib import Path
+import os
+import environ
+
+env = environ.Env(
+    # set casting, default value
+    DEBUG=(bool, True)
+)
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
-BASE_DIR = Path(__file__).resolve().parent.parent
+BASE_DIR = Path(__file__).resolve().parent
 
-# Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
+# Take environment variables from .env file
+environ.Env.read_env(os.path.join(BASE_DIR, '.env'))
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-^5@e(m+8_(@ljs$4p&u()5ivodjy=ylt!=%cz%2(6#sysep2*y'
+# False if not in os.environ because of casting above
+DEBUG = env('DEBUG')
 
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+# Raises Django's ImproperlyConfigured
+# exception if SECRET_KEY not in os.environ
+SECRET_KEY = env('SECRET_KEY')
 
 ALLOWED_HOSTS = []
-
 
 # Application definition
 
@@ -36,9 +43,13 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    "django.contrib.sites",
+#    "django.contrib.sites",
     "django_extensions"
 ]
+
+#Uncomment SITE_ID =1 and django.contrib.sites to perform task with a single task but django.sites enabled
+#Default site id since we migrated with 001
+#SITE_ID = 1
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
@@ -76,12 +87,12 @@ WSGI_APPLICATION = 'ecommerce.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': "bootcampecommerce",
-        "USER": "bootcamp",
-        "PASSWORD": "",
-        "HOST": "localhost",
-        "PORT": "5432",
+        'ENGINE': env('DATABASE_ENGINE'),
+        'NAME': env('DATABASE_NAME'),
+        "USER": env('DATABASE_USER'),
+        "PASSWORD": env('DATABASE_PASS'),
+        "HOST": env('DATABASE_HOST') ,
+        "PORT":  env('DATABASE_PORT'),
     }
 }
 

--- a/ecommerce/requirements.txt
+++ b/ecommerce/requirements.txt
@@ -1,3 +1,4 @@
 Django==3.2.9
 psycopg2-binary==2.9.2
 django-extensions==3.1.2
+django-environ==0.8.1


### PR DESCRIPTION
This is Kerem Serttas from Plentific bootcamp, I have change settings.py file to take all database variables from and .env file.  In addition, secret key is also transferred into .env file, therefore it is in fact secret now:).  This .env file is added to .gitignore since we don't want to share env variables. I have also commented django.contrib.sites since we only have a single site now, but you can uncomment two lines as described in the file to make the project work with django.contrib.sites. Finally, I also added django-environ and its version to reqiurements.txt since we want to keep track of versions and update requirements.